### PR TITLE
tweak gauges: better colors, ticks. Also, DRY

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,10 +10,10 @@
             google.load("jquery", "1.6.4");
             google.load('visualization', '1', {packages:['gauge']});
             google.setOnLoadCallback(function() {
-              drawChart("wikipedia", 60000, 1200, 500, 500, 300, 600);
+              drawChart("wikipedia", 60000, true);
               $(".chart").each(function(i, e) {
                 wikipedia = $(e).attr("id");
-                drawChart(wikipedia, 60000, 300, 120, 120, 60, 180);
+                drawChart(wikipedia, 60000, false);
               });
             });
         </script>

--- a/public/js/wikipulse.js
+++ b/public/js/wikipulse.js
@@ -1,6 +1,6 @@
 var charts = {};
 
-function drawChart(wikipedia, range, max, height, width, endGreen, endYellow) {
+function drawChart(wikipedia, range, combined) {
   var url = "/stats/" + wikipedia + "/" + range + ".json";
   $.getJSON(url, function(edits) {
     var data = new google.visualization.DataTable();
@@ -10,15 +10,25 @@ function drawChart(wikipedia, range, max, height, width, endGreen, endYellow) {
     data.setValue(0, 0, shortName(wikipedia));
     data.setValue(0, 1, edits);
 
+    var size = (combined ? 500 : 120),
+        max = (combined ? 1000 : 300),
+        endGreen = (combined ? 600 : 180),  // green = <10 edits/second (global gauge), <3 ed/s (single gauges)
+        endYellow = (combined ? 900 : 240); // yellow = 10-15 ed/s (global gauge), 3-5 ed/s (single gauges)
+                                            // red = >15 ed/s (global gauge), >5 ed/s (single gauges)
     var options = {
-        width: width,
-        height: height,
-        minorTicks: 10,
+        width: size,
+        height: size,
+        max: max,
+        minorTicks: (combined ? 2 : 5),
+        majorTicks: (combined ? ["0","200","","","",max] : ["0","50","","","","",max]),
+        greenColor: "GreenYellow",
         greenFrom: 0, greenTo: endGreen,
+        yellowColor: "Gold",
         yellowFrom: endGreen, yellowTo: endYellow,
-        redFrom: endYellow, redTo: max,
-        max: max
+        redColor: "Tomato",
+        redFrom: endYellow, redTo: max
     };
+
     var chart = null;
     if (charts[wikipedia]) {
       chart = charts[wikipedia];
@@ -27,7 +37,7 @@ function drawChart(wikipedia, range, max, height, width, endGreen, endYellow) {
       charts[wikipedia] = chart;
     }
     chart.draw(data, options);
-    var draw = 'drawChart("' + wikipedia + '",' + range + "," + max + "," + height + "," + width + "," + endGreen + "," + endYellow + ")";
+    var draw = 'drawChart("' + wikipedia + '",' + range + "," + combined + ")";
     setTimeout(draw, 1000);
   });
 }


### PR DESCRIPTION
- Use a more compact function signature for `drawChart`,
  which allows less repetition in the code that needs to call it
  (hence less opportunities for desynchronization).
- Rework placement of color thresholds so they make more sense
  (red was too large, for instance).
  Also, use softer colors to tone down the page and allow ticks to be more visible.
- Adjust ticks to the new limits to make visual inspection of the gauges easier.
  Showing the label for the first major tick also helps here.
